### PR TITLE
issue #62: reload main feed when changing the search bar content

### DIFF
--- a/AresNews/AresNews/App.xaml.cs
+++ b/AresNews/AresNews/App.xaml.cs
@@ -44,7 +44,7 @@ namespace AresNews
         {
 #if __LOCAL__
             // Set webservice
-            WService = new Service(host: "192.168.1.11",
+            WService = new Service(host: "192.168.1.18",
                                     port: 3000,
                                    sslCertificate: false);
 #else

--- a/AresNews/AresNews/Views/NewsPage.xaml
+++ b/AresNews/AresNews/Views/NewsPage.xaml
@@ -83,7 +83,7 @@
                         <controls:BorderlessEntry Grid.Column="1"
                                BackgroundColor="Transparent"
                                FontFamily="B-SemiBold"
-                               Text="{Binding SearchText}"
+                               Text="{Binding SearchText, Mode=TwoWay}"
                                PlaceholderColor="{StaticResource FontColor}"
                                TextColor="{StaticResource FontColor}"
                                x:Name="entrySearch"


### PR DESCRIPTION
## fixes
- During a search, the pull to refresh only updates within the search parameters

## Additional changes 
- Search Refresh uses the `` feeds/update `` API  endpoint