### PR TITLE
Fix: ios launch crash

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -106,8 +106,11 @@ namespace GamHubApp;
            IsLoading = false;
            
            // Close the popup
-           this.LoadingIndicator.Close();
-        }
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+               this.LoadingIndicator.Close();
+            });
+    }
         /// <summary>
         ///  Function to close the database 
         /// </summary>
@@ -217,8 +220,10 @@ namespace GamHubApp;
                     page = GetCurrentPage();
                 if (page.Navigation.NavigationStack.Any(p => p?.Id == popUp?.Id))
                     return;
-
-                page.ShowPopup(popUp);
+                MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    page.ShowPopup(popUp);
+                });
             }
             catch (Exception ex)
             {

--- a/App/Platforms/iOS/Info.plist
+++ b/App/Platforms/iOS/Info.plist
@@ -36,5 +36,7 @@
 	<string></string>
 	<key>CFBundleShortVersionString</key>
 	<string></string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
## Changes
- make sure the popup runs on the main thread 
- add [ITSAppUsesNonExemptEncryption](https://developer.apple.com/documentation/BundleResources/Information-Property-List/ITSAppUsesNonExemptEncryption) key to manifest