### PR TITLE
fix: [workflow] - android CD:  fix the release file path

### DIFF
--- a/.github/workflows/cd-android.yml
+++ b/.github/workflows/cd-android.yml
@@ -117,6 +117,6 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.playstore-service-account }}
           packageName: ${{ inputs.package-name }}
-          releaseFiles: ${{ github.workspace }}\${{ inputs.project-folder }}\bin\${{ inputs.build-config }}\${{ inputs.dotnet-version-target }}-android\${{ inputs.package-name }}-Signed.aab
+          releaseFiles: ${{ github.workspace }}/${{ inputs.project-folder }}/bin/${{ inputs.build-config }}/${{ inputs.dotnet-version-target }}-android/${{ inputs.package-name }}-Signed.aab
           track: production
           changesNotSentForReview: true


### PR DESCRIPTION
Change the release file path to prevent `Error: Unable to find any release file matching` error.

