### PR TITLE
fix: Article page HTML rendering

### DIFF
--- a/App/Models/Article.cs
+++ b/App/Models/Article.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using SQLite;
 using SQLiteNetExtensions.Attributes;
 using SQLiteNetExtensions.Extensions;
+using System.Reflection;
 
 namespace GamHubApp.Models;
 
@@ -139,6 +140,24 @@ public class Article
                     Text = Title
                 });
             }); ;
+        }
+    }
+
+    [Ignore]
+    public string HTMLContent
+    {
+        get
+        {
+
+            var assembly = Assembly.GetExecutingAssembly();
+            string style;
+            // Read the embedded resource
+            using (Stream stream = assembly.GetManifestResourceStream($"{assembly.GetName().Name}.Resources.Styles.ArticleStyle.css"))
+            using (StreamReader reader = new (stream))
+            {
+                style = $"<style type=\"text/css\">{reader.ReadToEnd()}</style>";
+            }
+            return style+Content;
         }
     }
 }

--- a/App/Resources/Styles/ArticleStyle.css
+++ b/App/Resources/Styles/ArticleStyle.css
@@ -14,7 +14,7 @@ label {
 }
 
 a {
-    color: #14813A;
+    color: #4AC776;
 }
 * {
     color: #ecebeb;

--- a/App/Resources/Styles/ArticleStyle.css
+++ b/App/Resources/Styles/ArticleStyle.css
@@ -1,0 +1,23 @@
+﻿@font-face {
+    font-family: TextFont;
+    src: url("file:///android_asset/Ubuntu-Medium.ttf")
+}
+/* This sets the width of all images to 50% of their original size */
+img, [class^="image-"] {
+    width: 250px;
+    height: auto;
+}
+
+label {
+    font-family: TextFont;
+    font-size: medium;
+    text-align: justify;
+    color: #ecebeb;
+}
+
+a {
+    color: #14813A;
+}
+* {
+    color: #ecebeb;
+}

--- a/App/Resources/Styles/ArticleStyle.css
+++ b/App/Resources/Styles/ArticleStyle.css
@@ -2,7 +2,6 @@
     font-family: TextFont;
     src: url("file:///android_asset/Ubuntu-Medium.ttf")
 }
-/* This sets the width of all images to 50% of their original size */
 img, [class^="image-"] {
     width: 250px;
     height: auto;
@@ -12,7 +11,6 @@ label {
     font-family: TextFont;
     font-size: medium;
     text-align: justify;
-    color: #ecebeb;
 }
 
 a {

--- a/App/Views/ArticlePage.xaml
+++ b/App/Views/ArticlePage.xaml
@@ -191,8 +191,7 @@
                         BackgroundColor="Transparent"
                        >
                         <WebView.Source>
-                            <HtmlWebViewSource Html="{Binding SelectedArticle.HTMLContent, Mode=OneWay}"
-                       />
+                            <HtmlWebViewSource Html="{Binding SelectedArticle.HTMLContent, Mode=OneWay}"/>
                         </WebView.Source>
                     </WebView>
 

--- a/App/Views/ArticlePage.xaml
+++ b/App/Views/ArticlePage.xaml
@@ -173,8 +173,23 @@
                     </Grid>
                 </Grid>
                 <!-- content -->
+                    <!-- NOTE: a bug prevent use from using WebView on iOS. see: https://github.com/dotnet/maui/issues/21604-->
+                
+               <Label Text="{Binding SelectedArticle.Content, Mode=OneWay}"
+                      FontFamily="P-Regular"
+                      IsVisible="{OnPlatform Android='false',
+                                             iOS='true'}"
+                      TextColor="{StaticResource FontColor}"
+                      Margin="10"
+                      TextType="Html"
+                      Grid.Row="3"
+                      />
                     <WebView Grid.Row="3"
-                             BackgroundColor="Transparent">
+                        IsVisible="{OnPlatform Android='true',
+                                        iOS='false'}"
+                        x:Name="contentView"
+                        BackgroundColor="Transparent"
+                       >
                         <WebView.Source>
                             <HtmlWebViewSource Html="{Binding SelectedArticle.HTMLContent, Mode=OneWay}"
                        />

--- a/App/Views/ArticlePage.xaml
+++ b/App/Views/ArticlePage.xaml
@@ -173,13 +173,13 @@
                     </Grid>
                 </Grid>
                 <!-- content -->
-                <Label Text="{Binding SelectedArticle.Content, Mode=OneWay}"
-                       FontFamily="P-Regular"
-                       TextColor="{StaticResource FontColor}"
-                       Margin="10"
-                       TextType="Html"
-                       Grid.Row="3"
+                    <WebView Grid.Row="3"
+                             BackgroundColor="Transparent">
+                        <WebView.Source>
+                            <HtmlWebViewSource Html="{Binding SelectedArticle.HTMLContent, Mode=OneWay}"
                        />
+                        </WebView.Source>
+                    </WebView>
 
                     <!-- Button to open to the default Browser -->
                 <Button Text="Read more"


### PR DESCRIPTION
## Changes 
introduce a CSS to render the article content

| Before | After |
|---|---|
|![photo_2025-01-29_15-57-34](https://github.com/user-attachments/assets/01e441be-a2c5-438a-9163-92da04c49b63)|![Screenshot_20250129-152935](https://github.com/user-attachments/assets/198a3379-a0a5-4c79-8bea-47a8d21e6fa7)|

closes #182 