### PR TITLE
Fix: Text-to-speech not working

### DIFF
--- a/App/Platforms/Android/AndroidManifest.xml
+++ b/App/Platforms/Android/AndroidManifest.xml
@@ -19,5 +19,8 @@
 			<action android:name="android.intent.action.VIEW" />
 			<data android:scheme="https"/>
 		</intent>
+		<intent>
+			<action android:name="android.intent.action.TTS_SERVICE" />
+		</intent>
 	</queries>
 </manifest>

--- a/App/Views/ArticlePage.xaml
+++ b/App/Views/ArticlePage.xaml
@@ -157,9 +157,13 @@
                         <Border Grid.Column="2"
                                Style="{StaticResource ButtonBorder}"
                                Padding="0"
-                               BackgroundColor="{Binding TtsColour}">
+                               BackgroundColor="{Binding TtsColour}"
+                                x:Name="TtsButton">
                                 <Border.Behaviors>
-                                    <mct:TouchBehavior Command="{Binding PlayTextToSpeech}"/>
+                                    <mct:TouchBehavior Command="{Binding PlayTextToSpeech}"
+                                                       BindingContext="{Binding BindingContext, 
+                                                                                Source={x:Reference thy},
+                                                                                x:DataType=ContentPage}"/>
                                 </Border.Behaviors>
 
                             <Label TextColor="{StaticResource Primary}"


### PR DESCRIPTION
Text-to-speech didn't work due to the input binding context of the button.
It's now fixed

closes #183