### PR TITLE
fix: Custom feed not loading after navigating from an article 

### DIFF
--- a/App/ViewModels/FeedsViewModel.cs
+++ b/App/ViewModels/FeedsViewModel.cs
@@ -618,7 +618,6 @@ public class FeedsViewModel : BaseViewModel
 
         try
         {
-            IsBusy = true;
             UpdateFeeds();
         }
         catch (Exception ex)

--- a/App/ViewModels/FeedsViewModel.cs
+++ b/App/ViewModels/FeedsViewModel.cs
@@ -359,10 +359,9 @@ public class FeedsViewModel : BaseViewModel
             {
                 // End the loading indicator
                 IsRefreshing = false;
-                IsBusy = false;
             } }
             
-        );
+        ).ContinueWith ((tr) => IsBusy = false);
         
     }
 
@@ -651,6 +650,7 @@ public class FeedsViewModel : BaseViewModel
     {
         if (!_dataLoaded) return;
         if (_feeds == null) return;
+        IsBusy = true;
 
         Collection<Feed> updatedFeeds;
         using (var conn = new SQLiteConnection(App.GeneralDBpath))
@@ -661,7 +661,10 @@ public class FeedsViewModel : BaseViewModel
         }
 
         if (updatedFeeds is null)
+        {
+            IsBusy = false;
             return;
+        }
 
         List<Feed> newFeeds = updatedFeeds.Where(feed => !_feeds.Any(item => item.Id == feed.Id)).ToList();
         List<Feed> removedFeeds = _feeds.Where(feed => !updatedFeeds.Any(item => item.Id == feed.Id)).ToList();
@@ -676,6 +679,7 @@ public class FeedsViewModel : BaseViewModel
         {
             _ =RemoveFeed(feed);
         }
+        IsBusy = false;
     }
 
     /// <summary>


### PR DESCRIPTION
This issue stemmed from the use of `IsBusy` when resuming the feeds page.
When we resume the feed page every time we navigate back from an article, the selected feed reloads, setting `IsBusy` to `true`.
This is set so that if any fee is added, the page stays up to date; the issue is that it gets triggered when we navigate back from an article as well, but we did not set `IsBusy` back to `false`.


fixes #197.