### PR TITLE
fix: Main feed - share button unresponsive

### DIFF
--- a/App/Controls/ArticlePreview.xaml
+++ b/App/Controls/ArticlePreview.xaml
@@ -110,7 +110,7 @@
                              Style="{StaticResource ButtonBorder}" 
                              BackgroundColor="{StaticResource LightDark}" >
                         <Border.Behaviors>
-                            <mct:TouchBehavior Command="{Binding Article.ShareArticle}"
+                            <mct:TouchBehavior Command="{Binding Article.ShareArticle, Source={x:Reference preview}}"
                                                BindingContext="{Binding BindingContext, 
                                                                  Source={x:Reference preview}, 
                                                                  x:DataType=ContentView}"/>


### PR DESCRIPTION
### Initial issue
On the main feed, the share options wouldn't pop up when pressing the share button on an article

### Changes
- **Article Preview's share button:** be more specific on the source