### PR TITLE
fix: no internet connection handler

### DIFF
--- a/App/Services/Fetcher.cs
+++ b/App/Services/Fetcher.cs
@@ -429,10 +429,15 @@ public class Fetcher
     /// <exception cref="Exception"></exception>
     private async Task HandleHttpException(HttpResponseMessage err)
     {
+        string errMsg = await err.Content.ReadAsStringAsync();
 #if DEBUG
-        throw new Exception(await err.Content.ReadAsStringAsync());
+        throw new Exception(errMsg);
 #else
-        SentrySdk.CaptureException(new Exception(await err.Content.ReadAsStringAsync()));
+        if (Connectivity.Current.NetworkAccess != NetworkAccess.Internet
+            && errMsg.Contains("internet connection"))
+            // If the error is being thrown because there is no internet: there is no point reporting it 
+            return;
+        SentrySdk.CaptureException(new Exception(errMsg));
 #endif
     }
 

--- a/App/Services/Fetcher.cs
+++ b/App/Services/Fetcher.cs
@@ -83,7 +83,7 @@ public class Fetcher
     {
         return Fetcher.Sources =  await WebService.Get<Collection<Source>>(controller: "sources", 
                                                         action: "getAll",
-                                                         unSuccessCallback: e => _ = HandleHttpException(e));
+                                                        unSuccessCallback: e => _ = HandleHttpException(e));
     }
     /// <summary>
     /// Get the feed of an article
@@ -430,13 +430,14 @@ public class Fetcher
     private async Task HandleHttpException(HttpResponseMessage err)
     {
         string errMsg = await err.Content.ReadAsStringAsync();
+
+        if (Connectivity.Current.NetworkAccess != NetworkAccess.Internet
+            && (errMsg.Contains("internet connection") || errMsg.Contains("Connection failure")))
+            // If the error is being thrown because there is no internet: there is no point reporting it 
+            return;
 #if DEBUG
         throw new Exception(errMsg);
 #else
-        if (Connectivity.Current.NetworkAccess != NetworkAccess.Internet
-            && errMsg.Contains("internet connection"))
-            // If the error is being thrown because there is no internet: there is no point reporting it 
-            return;
         SentrySdk.CaptureException(new Exception(errMsg));
 #endif
     }

--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -127,6 +127,9 @@ public class AppShellViewModel : BaseViewModel
     /// </summary>
     public async Task NotificationSetup()
     {
+        if (Connectivity.Current.NetworkAccess != NetworkAccess.Internet)
+            return;
+
         if ((await _firebasePushPermissions.GetAuthorizationStatusAsync() is not Plugin.FirebasePushNotifications.Model.AuthorizationStatus.Granted)
             && Preferences.Get(_notificationKey, true))
 #if ANDROID


### PR DESCRIPTION
Updating Fetcher's error handler to avoid reporting issues related to internet connection missing (because there is nothing we can really do about it)

### Additional but related change
Manage the notification setup when the device is offline. There was a lot of instances where the app would crash on the notification setup if the device is offline on the very first run.

Resolves #262