### PR TITLE
fix: update deals on article navigation

### DIFF
--- a/App/AppShell.xaml.cs
+++ b/App/AppShell.xaml.cs
@@ -41,6 +41,11 @@ public partial class AppShell : Shell
         Task partnersTask = _currentApp.LoadPartners();
         Task notifTask = _vm.NotificationSetup();
         await Task.WhenAll(partnersTask, notifTask);
+    }
+
+    protected override async void OnNavigated(ShellNavigatedEventArgs args)
+    {
+        base.OnNavigated(args);
         await _vm.UpdateDeals(); 
     }
 

--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -114,7 +114,10 @@ public class AppShellViewModel : BaseViewModel
     /// <returns></returns>
     public async Task UpdateDeals()
     {
-        DealEnabled = Preferences.Get(AppConstant.DealPageEnable, true);
+        if (!(DealEnabled = Preferences.Get(AppConstant.DealPageEnable, true)))
+            return;
+
+        await dataFetcher.GetDeals();
 
         // Set the deal count
         BadgeCounterService.SetCount(await dataFetcher.UpdateDeals());


### PR DESCRIPTION
Deal are not loading when opening an article directly from an notification.
to solve this I decided to move the deal update to the `OnNavigation` event, this offers a couple of benefits:
- allowing the deal page to appears
- make sure that the deals are loaded regularly 
- keep track of the deal preferences settings

I was skeptical of this solution at first, mostly because of performance drawbacks, but a user wouldn't navigate this much through the app