### PR TITLE
Imp: deal offline access

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -175,6 +175,7 @@ public partial class App : Application
      {
          AppShell mainPage = ((AppShell)Current.Windows[0].Page);
          Page currentPage = mainPage.CurrentPage;
+         mainPage.Resume();
 
          if (currentPage.ToString() == "GamHubApp.Views.ArticlePage")
          {

--- a/App/AppShell.xaml.cs
+++ b/App/AppShell.xaml.cs
@@ -69,4 +69,9 @@ public partial class AppShell : Shell
 
         }
     }
+
+    public void Resume()
+    {
+        _vm.DealEnabled = Connectivity.NetworkAccess == NetworkAccess.Internet;
+    }
 }

--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -116,6 +116,13 @@ public class AppShellViewModel : BaseViewModel
     /// <returns></returns>
     public async Task UpdateDeals()
     {
+        if (Connectivity.NetworkAccess != NetworkAccess.Internet)
+        {
+            // Disable the deals if we aren't connected to the internet
+            DealEnabled = false;
+            return;
+        }
+
         if (!(DealEnabled = Preferences.Get(AppConstant.DealPageEnable, true)))
             return;
 


### PR DESCRIPTION
The deal page cannot function in offline mode. Therefore we need to hide it from the navigation bar when the app is offline.