### PR TITLE
fix: crash android fast boot notification

### DIFF
--- a/App/ViewModels/AppShellViewModel.cs
+++ b/App/ViewModels/AppShellViewModel.cs
@@ -294,7 +294,12 @@ public class AppShellViewModel : BaseViewModel
             {
                 MainThread.BeginInvokeOnMainThread(async () => 
                 {
-                    await Shell.Current.GoToAsync("///MyDealsPage");
+                    try
+                    {
+                        await Shell.Current.GoToAsync("///MyDealsPage");
+                    } 
+                    catch 
+                    {}
 
                     await Browser.OpenAsync(e.Data["url"].ToString());
                 }); 


### PR DESCRIPTION
Sometimes then opening a deal notification reminder in fast boot the app crashes. it is because the "///MyDealsPage" doesn't exist when the app hasn't been loaded, as the deal page is the only page that is enabled programmatically.