### PR TITLE
fix: article page menu tab

### DIFF
--- a/App/Views/ArticlePage.xaml
+++ b/App/Views/ArticlePage.xaml
@@ -346,14 +346,17 @@
             
             <!-- Menu overlay -->
             <Border HorizontalOptions="End"
-                   x:Name="dropdownMenu"
-                   VerticalOptions="Start"
-                   BackgroundColor="{StaticResource LightDark}"
-                   HeightRequest="0"
-                   Padding="0"
-                   WidthRequest="50">
-                <StackLayout IsVisible="{Binding IsMenuOpen}">
-                    <Grid >
+                    x:Name="dropdownMenu"
+                    VerticalOptions="Start"
+                    BackgroundColor="{StaticResource LightDark}"
+                    HeightRequest="0"
+                    Padding="0"
+                    StrokeShape="RoundRectangle 0 0 6 0"
+                    Grid.RowSpan="2"
+                    WidthRequest="50"
+                    IsVisible="{Binding IsMenuOpen}">
+                <Grid RowDefinitions="*,1,*">
+                    <Grid Grid.Row="0">
                         <Grid.Behaviors>
                             <mct:TouchBehavior Command="{Binding Browse}"
                                                BindingContext="{Binding BindingContext, 
@@ -364,16 +367,18 @@
                             <TapGestureRecognizer Tapped="MenuItem_Tapped"/>
                         </Grid.GestureRecognizers>
                         <Label Text="Open full article"
-                                   TextColor="{StaticResource FontColor}"
-                                   FontFamily="P-SemiBold"
-                                   FontSize="18"
-                                   HorizontalOptions="Center"/>
+                               TextColor="{StaticResource FontColor}"
+                               FontFamily="P-SemiBold"
+                               FontSize="18"
+                               HorizontalTextAlignment="Center"
+                               VerticalOptions="Center"/>
                     </Grid>
                     <BoxView HeightRequest="1"
-                                 WidthRequest="30"
-                                 BackgroundColor="{StaticResource FontColor}"
-                                 Opacity="0.1"/>
-                    <Grid>
+                             Grid.Row="1"
+                             Margin="5,0"
+                             BackgroundColor="{StaticResource FontColor}"
+                             Opacity="0.1"/>
+                    <Grid Grid.Row="2">
                         <Grid.Behaviors>
                             <mct:TouchBehavior Command="{Binding SelectedArticle.ShareArticle}"
                                                BindingContext="{Binding BindingContext, 
@@ -384,12 +389,13 @@
                             <TapGestureRecognizer Tapped="MenuItem_Tapped"/>
                         </Grid.GestureRecognizers>
                         <Label Text="Share"
-                                   TextColor="{StaticResource FontColor}"
-                                   FontFamily="P-SemiBold"
-                                   FontSize="18"
-                                   HorizontalOptions="Center"/>
+                               TextColor="{StaticResource FontColor}"
+                               FontFamily="P-SemiBold"
+                               FontSize="18"
+                               HorizontalTextAlignment="Center"
+                               VerticalOptions="Center"/>
                     </Grid>
-                </StackLayout>
+                </Grid>
             </Border>
         </Grid>
     </ContentPage.Content>


### PR DESCRIPTION
The dropdown menu of the article page still has the rendering issue Feed page's used to have.
This PR aims at fixing this. 