### PR TITLE
fix: deal filter - design iOS 

### DIFF
--- a/App/Views/PopUps/DealFilterPopUp.xaml
+++ b/App/Views/PopUps/DealFilterPopUp.xaml
@@ -57,7 +57,7 @@
                                     HorizontalOptions="End"
                                     VerticalOptions="Center"
                                     WidthRequest="80"
-                                    Grid.Column="1"
+                                    Grid.Column="2"
                                     IsToggled="{Binding IsSelected}"
                                     Background="Transparent">
                                 <Switch.Triggers>


### PR DESCRIPTION
On the deal filter popup, the DRM label collide with the switch box, which is less than ideal.

Turned out I set the wrong `Grid.Column` value
